### PR TITLE
fix(dependabot): ensure updates target the dev branch

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -9,3 +9,4 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    target-branch: "dev"


### PR DESCRIPTION
This pull request includes a small update to the `.github/dependabot.yaml` file. The change specifies the `target-branch` for Dependabot updates, setting it to `"dev"` instead of using the default branch.

* [`.github/dependabot.yaml`](diffhunk://#diff-ee0c08340ace9ac3ce3c78e2377968bca2376b8bfd9a7a48d96515f5490a902cR12): Added the `target-branch` property with the value `"dev"` to direct Dependabot updates to the `dev` branch.