### PR TITLE
refactor(rust): upgrade GitHub Actions to use version 4 of upload and…

### DIFF
--- a/.github/workflows/create_dev.yml
+++ b/.github/workflows/create_dev.yml
@@ -45,7 +45,7 @@ jobs:
           cp target/${{ matrix.target }}/release/github-ntfy release/${{ matrix.name }}
 
       - name: Upload binaire comme artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.name }}
           path: release/${{ matrix.name }}
@@ -72,7 +72,7 @@ jobs:
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Télécharger tous les binaires
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           path: binaries
 

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -77,7 +77,7 @@ jobs:
           cp target/${{ matrix.target }}/release/github-ntfy release/${{ matrix.name }}
 
       - name: Upload binaire comme artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.name }}
           path: release/${{ matrix.name }}
@@ -104,7 +104,7 @@ jobs:
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Télécharger tous les binaires
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           path: binaries
 
@@ -137,7 +137,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Télécharger tous les binaires
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           path: binaries
 


### PR DESCRIPTION
This pull request updates GitHub Actions workflows to use the latest versions of the `upload-artifact` and `download-artifact` actions. These changes ensure compatibility with the most recent features and improvements provided by the actions.

Updates to `.github/workflows/create_dev.yml`:

* Updated the `upload-artifact` action from version `v3` to `v4` for uploading binaries.
* Updated the `download-artifact` action from version `v3` to `v4` for downloading binaries.

Updates to `.github/workflows/create_release.yml`:

* Updated the `upload-artifact` action from version `v3` to `v4` for uploading binaries.
* Updated the `download-artifact` action from version `v3` to `v4` for downloading binaries in two separate steps. [[1]](diffhunk://#diff-20b4af9a743edb3be348e23e792bf3fb0ad92637b44fafa6c5de878558abce7dL107-R107) [[2]](diffhunk://#diff-20b4af9a743edb3be348e23e792bf3fb0ad92637b44fafa6c5de878558abce7dL140-R140)