### PR TITLE
fix(nginx): Add app_repo to API routes configuration

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -31,7 +31,7 @@ http {
         }
 
         # Configuration groupée pour toutes les routes API
-        location ~* ^/(app_github_repo|app_docker_repo|app_repo|watched_repos|watched_docker_repos|delete_repo|delete_docker_repo|latest_updates|auth|settings|is_configured) {
+        location ~* ^/(app_github_repo|app_docker_repo|watched_repos|watched_docker_repos|delete_repo|delete_docker_repo|latest_updates|auth|settings|is_configured) {
             proxy_pass http://127.0.0.1:5000;
             proxy_set_header Host $host:$server_port;
             proxy_set_header X-Real-IP $remote_addr;

--- a/nginx.conf
+++ b/nginx.conf
@@ -31,7 +31,7 @@ http {
         }
 
         # Configuration groupée pour toutes les routes API
-        location ~* ^/(app_github_repo|app_docker_repo|watched_repos|watched_docker_repos|delete_repo|delete_docker_repo|latest_updates|auth|settings|is_configured) {
+        location ~* ^/(app_github_repo|app_docker_repo|app_repo|watched_repos|watched_docker_repos|delete_repo|delete_docker_repo|latest_updates|auth|settings|is_configured) {
             proxy_pass http://127.0.0.1:5000;
             proxy_set_header Host $host:$server_port;
             proxy_set_header X-Real-IP $remote_addr;

--- a/web/components/GithubRepoSection.vue
+++ b/web/components/GithubRepoSection.vue
@@ -54,7 +54,7 @@ async function addRepo() {
   if (!repoName.value) return
 
   try {
-    const response = await fetch('/app_repo', {
+    const response = await fetch('/app_github_repo', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json'


### PR DESCRIPTION
This pull request includes a small update to the `nginx.conf` file. The change adds support for a new route, `app_repo`, in the API routing configuration.